### PR TITLE
在H5和钉钉版的PhotoField上增加onImagePreview回调，更新文档

### DIFF
--- a/docs/PhotoField.md
+++ b/docs/PhotoField.md
@@ -66,6 +66,7 @@
 |----------|--------------|------------------|
 | onChange | values, photos   | 上传图片回调，values 是一个数组，里面为上传的多张图片 url, photos 为变化后的 fileList 的合集|
 | onDelete | index        | 删除图片回调，index 是序号 |
+| onImagePreview | index        | 点击图片预览回调，index 是序号，如不设置该回调，则使用ImageViewer预览图片，如设置该回调，需自行处理如何进行图片预览 |
 
 ### onChange 的 fileList 的枚举格式有如下几种
 ```javascript

--- a/src/PhotoField/DdPhotoField.jsx
+++ b/src/PhotoField/DdPhotoField.jsx
@@ -118,7 +118,7 @@ class PhotoField extends React.Component {
       tip,
       onPickerClick: () => { this.onPickHandler(); },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.handlePreview(index); },
+      onImagePreview: (index) => { this.props.onImagePreview === noop ? this.handlePreview(index) : this.props.onImagePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />
@@ -135,6 +135,7 @@ PhotoField.defaultProps = {
   maxUpload: 12, // 总共上传图片总数
   readOnly: false,
   onChange: noop,
+  onImagePreview: noop,
   photoList: [],
   locale: 'zh-cn',
   icon: undefined,
@@ -163,6 +164,7 @@ PhotoField.propTypes = {
   readOnly: PropTypes.bool,
   onChange: PropTypes.func,
   onDelete: PropTypes.func,
+  onImagePreview: PropTypes.func,
   required: PropTypes.bool,
   tip: PropTypes.string,
 };

--- a/src/PhotoField/DdPhotoField.jsx
+++ b/src/PhotoField/DdPhotoField.jsx
@@ -118,7 +118,7 @@ class PhotoField extends React.Component {
       tip,
       onPickerClick: () => { this.onPickHandler(); },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.props.onImagePreview === noop ? this.handlePreview(index) : this.props.onImagePreview(index); },
+      onImagePreview: (index) => { this.props.onImagePreview ? this.props.onImagePreview(index) : this.handlePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />
@@ -135,7 +135,7 @@ PhotoField.defaultProps = {
   maxUpload: 12, // 总共上传图片总数
   readOnly: false,
   onChange: noop,
-  onImagePreview: noop,
+  onImagePreview: undefined,
   photoList: [],
   locale: 'zh-cn',
   icon: undefined,

--- a/src/PhotoField/DdPhotoField.jsx
+++ b/src/PhotoField/DdPhotoField.jsx
@@ -105,6 +105,7 @@ class PhotoField extends React.Component {
       columns, placeholder, label,
       photoList, required,
       maxUpload, readOnly, className, tip,
+      onImagePreview
     } = this.props;
     const paneProps = {
       columns,
@@ -118,7 +119,7 @@ class PhotoField extends React.Component {
       tip,
       onPickerClick: () => { this.onPickHandler(); },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.props.onImagePreview ? this.props.onImagePreview(index) : this.handlePreview(index); },
+      onImagePreview: (index) => { onImagePreview ? onImagePreview(index) : this.handlePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />

--- a/src/PhotoField/PhotoField.jsx
+++ b/src/PhotoField/PhotoField.jsx
@@ -197,7 +197,7 @@ class PhotoField extends React.Component {
       files: this.getFiles(),
       ref: (c) => { this.pane = c; },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.props.onImagePreview === undefined ? this.handlePreview(index) : this.props.onImagePreview(index); },
+      onImagePreview: (index) => { this.props.onImagePreview ? this.props.onImagePreview(index) : this.handlePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />

--- a/src/PhotoField/PhotoField.jsx
+++ b/src/PhotoField/PhotoField.jsx
@@ -197,7 +197,7 @@ class PhotoField extends React.Component {
       files: this.getFiles(),
       ref: (c) => { this.pane = c; },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.handlePreview(index); },
+      onImagePreview: (index) => { this.props.onImagePreview === undefined ? this.handlePreview(index) : this.props.onImagePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />
@@ -221,6 +221,7 @@ PhotoField.defaultProps = {
   corpId: undefined,
   placeholder: undefined,
   onDelete: undefined,
+  onImagePreview: undefined,
   required: undefined,
   name: undefined,
   url: undefined,
@@ -244,6 +245,7 @@ PhotoField.propTypes = {
   readOnly: PropTypes.bool,
   onChange: PropTypes.func,
   onDelete: PropTypes.func,
+  onImagePreview: PropTypes.func,
   required: PropTypes.bool,
   name: PropTypes.string,
   url: PropTypes.string,

--- a/src/PhotoField/PhotoField.jsx
+++ b/src/PhotoField/PhotoField.jsx
@@ -182,6 +182,7 @@ class PhotoField extends React.Component {
       columns, placeholder, label,
       photoList, required, locale,
       maxUpload, readOnly, className, tip,
+      onImagePreview
     } = this.props;
     const paneProps = {
       columns,
@@ -197,7 +198,7 @@ class PhotoField extends React.Component {
       files: this.getFiles(),
       ref: (c) => { this.pane = c; },
       onImageDelete: (index) => { this.handleDeleteImage(index); },
-      onImagePreview: (index) => { this.props.onImagePreview ? this.props.onImagePreview(index) : this.handlePreview(index); },
+      onImagePreview: (index) => { onImagePreview ? onImagePreview(index) : this.handlePreview(index); },
     };
     return (
       <PhotoFieldPane {...paneProps} />


### PR DESCRIPTION
根据 #124 完成了在H5和钉钉板的PhotoField上增加onImagePreview回调。

本次commit只更新了代码和文档，没有更新版本号，看gulpfile.js应该是saltui的负责人运行npm run pub自动更新，如果需要我更新其他的信息，请告知。