### PR TITLE
feat:use standalone PropTypes instead of React.PropTypes

### DIFF
--- a/src/Drawer/Drawer.jsx
+++ b/src/Drawer/Drawer.jsx
@@ -6,13 +6,14 @@
  * All rights reserved.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import RcDrawer from 'rc-drawer';
 import { prefixClass } from '../Context';
 
 class Drawer extends React.Component {
 
   static propTypes = {
-    prefixCls: React.PropTypes.string,
+    prefixCls: PropTypes.string,
   };
 
   static defaultProps = {

--- a/src/FoldablePane/FoldablePane.jsx
+++ b/src/FoldablePane/FoldablePane.jsx
@@ -6,17 +6,18 @@
  * All rights reserved.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import DirectionBottomIcon from 'salt-icon/lib/DirectionBottom';
 import classnames from 'classnames';
 import Context from '../Context';
 
 class FoldablePane extends React.Component {
   static propTypes = {
-    className: React.PropTypes.string,
-    children: React.PropTypes.node,
-    foldHeight: React.PropTypes.number,
-    isFold: React.PropTypes.bool,
-    onFold: React.PropTypes.func,
+    className: PropTypes.string,
+    children: PropTypes.node,
+    foldHeight: PropTypes.number,
+    isFold: PropTypes.bool,
+    onFold: PropTypes.func,
   };
 
   static defaultProps = {


### PR DESCRIPTION
React has removed the PropTypes in new version