### PR TITLE
fix: picker模式下，readOnly状态不需要显示placeholder

### DIFF
--- a/src/PickerField/PickerField.jsx
+++ b/src/PickerField/PickerField.jsx
@@ -183,7 +183,7 @@ class PickerField extends React.Component {
           className={Context.prefixClass('picker-field-content')}
         >
           {!t.state.confirmedValue[0]
-            ? <div className={Context.prefixClass('omit picker-field-placeholder')}>{t.props.placeholder || i18n[t.props.locale].placeholder}</div>
+            ? <div className={Context.prefixClass('omit picker-field-placeholder')}>{t.props.readOnly ? '' : (t.props.placeholder || i18n[t.props.locale].placeholder)}</div>
             : ''}
           {t.state.confirmedValue[0] ? (
             <div className={Context.prefixClass('picker-field-value FBH FBAC')}>


### PR DESCRIPTION
描述：目前下拉单选和下拉多选都会出现这个问题。