### PR TITLE
Fix DatetimeField

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
   ],
   "env": {
     "browser": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "rules": {
     "import/no-extraneous-dependencies": "off",

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -19,14 +19,16 @@
   },
   "homepage": "https://github.com/salt-ui/saltui#readme",
   "devDependencies": {
-    "babel-core": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-eslint": "^8.0.3",
+    "babel-jest": "^23.6.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-react-app": "^3.1.1",
     "babel-preset-stage-1": "^6.24.1",
     "browser-sync": "^2.18.13",
     "browser-sync-webpack-plugin": "^1.2.0",
@@ -34,6 +36,8 @@
     "co": "^4.6.0",
     "colors": "^1.1.2",
     "css-loader": "^0.28.7",
+    "enzyme": "^3.8.0",
+    "enzyme-adapter-react-16": "^1.7.1",
     "eslint": "^5.9.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",
@@ -52,6 +56,7 @@
     "gulp-uglify": "^3.0.0",
     "happypack": "^4.0.0-beta.2",
     "inquirer": "^3.3.0",
+    "jest": "^23.6.0",
     "progress-bar-webpack-plugin": "^1.10.0",
     "react": "16.x",
     "react-dom": "16.x",
@@ -90,5 +95,26 @@
     "salt-icon": "^3.1.4",
     "uploadcore": "^2.3.1",
     "uxcore-formatter": "^0.1.6"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest"
+    },
+    "testMatch": [
+      "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
+      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}"
+    ],
+    "testEnvironment": "jsdom",
+    "setupTestFrameworkScriptFile": "<rootDir>/config/jest/setupTests.js"
+  },
+  "babel": {
+    "presets": [
+      "env",
+      "stage-1",
+      "react-app"
+    ],
+    "plugins": [
+      "add-module-exports"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/salt-ui/saltui#readme",
   "devDependencies": {
-    "babel-core": "^6.26.3",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.3",
     "babel-jest": "^23.6.0",
     "babel-loader": "^7.1.2",

--- a/src/Datetime/Datetime.jsx
+++ b/src/Datetime/Datetime.jsx
@@ -23,6 +23,7 @@ const {
   needUpdateSlotValue,
   getOptions,
   getDaysByMonth,
+  getMonthsByYear,
   addZero,
   formatFromProps,
   formatText,
@@ -210,6 +211,20 @@ class Datetime extends React.Component {
         text: addZero(item.text) + (unit || ''),
       }));
       data[2] = dayArr;
+      updateObj.data = data;
+    } else if (columnsStyle === 'Y') {
+      // 修改年，动态计算月
+      let monthArr = getMonthsByYear({ minDate, maxDate, year: yearValue });
+      monthArr = formatText(monthArr, i18n[locale].surfix.M, this.props);
+      data[1] = monthArr;
+
+      // 修改年，动态计算日
+      let dayArr = getDaysByMonth({
+        minDate, maxDate, year: yearValue, month: monthValue,
+      });
+      dayArr = formatText(dayArr, i18n[locale].surfix.D, this.props);
+      data[2] = dayArr;
+
       updateObj.data = data;
     }
     this.setState(updateObj);

--- a/src/Datetime/__test__/Datetime.test.jsx
+++ b/src/Datetime/__test__/Datetime.test.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import Datetime from '../Datetime';
+import { getOptions } from '../util/date';
+import { getMonthsByYear } from '../util/base';
+
+describe('Datetime', () => {
+  const monthIndex = 1;
+  const dayIndex = 2;
+
+  it('setup without crash', () => {
+    const wrapper = shallow(<Datetime />);
+    expect(wrapper).toBeTruthy();
+  });
+
+  test.skip('month gap, minDate and maxDate', () => {
+    const minDate = new Date('2018-11-27').getTime();
+    const maxDate = new Date('2018-12-07').getTime();
+    const title = 'test minDate';
+    const onChange = jest.fn();
+    const wrapper = mount(<Datetime
+      columns={Datetime.YMD}
+      minDate={minDate}
+      maxDate={maxDate}
+      title={title}
+      onChange={onChange}
+    />);
+    expect(wrapper.find('Slot').props().title).toEqual(title);
+    expect(wrapper.find('Slot').props().value).toBeInstanceOf(Array);
+
+    const dayArr = wrapper.find('Slot').props().data[dayIndex];
+    expect(dayArr[0].value).toBe(1);
+    expect(dayArr[dayArr.length - 1].value).toBe(7);
+
+    const newValue = [
+      { value: 2018, text: '2018年' },
+      { value: 10, text: '11月' },
+      { value: 30, text: '30日' },
+    ];
+    wrapper.instance().handleChange(newValue, 1);
+    const newData = wrapper.instance().state.data;
+    expect(newData[dayIndex].length).toBe(3);
+    expect(newData[dayIndex][0].value).toBe(28);
+    expect(newData[dayIndex][newData[dayIndex].length - 1].value).toBe(30);
+  });
+
+  test('year gap, minDate and maxDate', () => {
+    const minDate = new Date('2018-12-27').getTime();
+    const maxDate = new Date('2019-01-07').getTime();
+    const title = 'test minDate';
+    const onChange = jest.fn();
+    const wrapper = mount(<Datetime
+      columns={Datetime.YMD}
+      minDate={minDate}
+      maxDate={maxDate}
+      title={title}
+      onChange={onChange}
+    />);
+    expect(wrapper.find('Slot').props().title).toEqual(title);
+    expect(wrapper.find('Slot').props().value).toBeInstanceOf(Array);
+
+    const dayArr = wrapper.find('Slot').props().data[dayIndex];
+    expect(dayArr[0].value).toBe(28);
+    expect(dayArr[dayArr.length - 1].value).toBe(31);
+
+    const newValue = [
+      { value: 2019, text: '2019年' },
+      { value: 0, text: '01月' },
+      { value: 5, text: '05日' },
+    ];
+    wrapper.instance().handleChange(newValue, 0);
+    const newData = wrapper.instance().state.data;
+    expect(newData[monthIndex].length).toBe(1);
+    expect(newData[monthIndex][0].value).toBe(0);
+    expect(newData[dayIndex].length).toBe(7);
+    expect(newData[dayIndex][0].value).toBe(1);
+    expect(newData[dayIndex][newData[dayIndex].length - 1].value).toBe(7);
+  });
+});
+
+describe('getOptions', () => {
+  const defaultProps = {
+    className: '',
+    locale: 'zh-cn',
+    columns: 'YMD',
+    onConfirm: _ => _,
+    onCancel: _ => _,
+    onChange: _ => _,
+    slotRef: _ => _,
+    minuteStep: 1,
+    disabledDate: () => [],
+    title: undefined,
+    value: undefined,
+    confirmText: undefined,
+    cancelText: undefined,
+    disabledTime: undefined,
+  };
+
+  test('month gap', () => {
+    const minDate = new Date('2018-11-27').getTime();
+    const maxDate = new Date('2018-12-07').getTime();
+    const props = {
+      minDate,
+      maxDate,
+      ...defaultProps,
+    };
+
+    const monthIndex = 1;
+    const options = getOptions(undefined, props);
+    const monthArr = options[monthIndex];
+    expect(monthArr.length).toBe(2);
+    expect(monthArr[0].value).toBe(10);
+    expect(monthArr[1].value).toBe(11);
+  });
+
+  test('year gap', () => {
+    const minDate = new Date('2018-12-27').getTime();
+    const maxDate = new Date('2019-01-07').getTime();
+    const props = {
+      minDate,
+      maxDate,
+      ...defaultProps,
+    };
+
+    const monthIndex = 1;
+    let options = getOptions(undefined, props);
+    let monthArr = options[monthIndex];
+    expect(monthArr[0].value).toBe(11);
+
+    options = getOptions({ value: new Date('2019-01-02').getTime() }, props);
+    monthArr = options[monthIndex];
+    expect(monthArr[0].value).toBe(0);
+  });
+});
+
+describe('getMonthsByYear', () => {
+  test('month gap', () => {
+    const minDate = new Date('2018-11-27').getTime();
+    const maxDate = new Date('2018-12-07').getTime();
+
+    const monthArr = getMonthsByYear({ minDate, maxDate, year: 2018 });
+    expect(monthArr).toBeInstanceOf(Array);
+    expect(monthArr.length).toBe(2);
+    expect(monthArr[0].value).toBe(10);
+    expect(monthArr[1].value).toBe(11);
+  });
+
+  test('year gap', () => {
+    const minDate = new Date('2018-12-27').getTime();
+    const maxDate = new Date('2019-01-07').getTime();
+
+    let monthArr = getMonthsByYear({ minDate, maxDate, year: 2018 });
+    expect(monthArr).toBeInstanceOf(Array);
+    expect(monthArr.length).toBe(1);
+    expect(monthArr[0].value).toBe(11);
+
+    monthArr = getMonthsByYear({ minDate, maxDate, year: 2019 });
+    expect(monthArr).toBeInstanceOf(Array);
+    expect(monthArr.length).toBe(1);
+    expect(monthArr[0].value).toBe(0);
+  });
+});

--- a/src/Datetime/util/base.js
+++ b/src/Datetime/util/base.js
@@ -243,7 +243,7 @@ function parseDate(value) {
  * @param { String | Number} minDate
  * @param { String | Number } maxDate
  * @param { Number } year
- * @returns year<array>
+ * @returns month<array>
  */
 function getMonthsByYear({ minDate, maxDate, year }) {
   const max = new Date(maxDate);


### PR DESCRIPTION
- `DatetimeField` 组件跨年选择问题，当选择列为“年”时，会重新计算月列和日列的选择范围。
- 增加对跨年、跨月的测试。
