### PR TITLE
修改了新版本的scrolllist

### DIFF
--- a/demo/ScrollList/ScrollListDemo.jsx
+++ b/demo/ScrollList/ScrollListDemo.jsx
@@ -40,17 +40,37 @@ function getJsonp(page, size) {
 
 const propsMap = [
   {
-    title: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={20} src="https://img.alicdn.com/tps/TB1amOaKpXXXXbsXVXXXXXXXXXX-144-144.png" />标题文字(如姓名)</span>,
+    title: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={20} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />标题文字(如姓名)</span>,
+    borderType: 'full-border',
   },
   {
-    description: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={20} src="https://img.alicdn.com/tps/TB1amOaKpXXXXbsXVXXXXXXXXXX-144-144.png" />标题文字(如姓名)</span>,
+    description: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={40} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />标题文字(如姓名)</span>,
+    borderType: 'cut-border',
+  },
+  {
+    avatar: <Avatar name="tingle" size={40} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />,
+    title: '标题文字(如姓名)',
+    description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
+    borderType: 'no-border',
+    totalNumber: true,
+  },
+  {
+    avatar: 'https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png',
+    title: '标题文字(如姓名)',
+    description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
+    borderType: 'cut-border',
+    extra: <DirectionRight name="direction-right" className="newlist-demo-icon" />,
+    totalNumber: 10000,
   },
   {
     img: 'https://gw.alicdn.com/tfs/TB15larRXXXXXbcXpXXXXXXXXXX-300-300.jpg',
     title: '标题文字(如姓名)',
+    className: 'badge-top-right',
     badge: <Badge text="徽章文本" style={{ marginLeft: 10, background: '#ff6600' }} />,
     description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
     extra: <DirectionRight name="direction-right" className="newlist-demo-icon" />,
+    totalNumber: 4,
+    borderType: 'no-border',
   },
   {
     img: 'https://gw.alicdn.com/tfs/TB15larRXXXXXbcXpXXXXXXXXXX-300-300.jpg',
@@ -172,6 +192,7 @@ class Demo extends React.Component {
     const curr = this.state.pageNum;
     this.setState({ loading: true });
     console.log('will load page', curr);
+    // if (curr >= 1) return;
     if (curr >= 3) {
       this.setState({
         loading: false,
@@ -180,7 +201,6 @@ class Demo extends React.Component {
         hasError: false,
       });
       console.log('no more');
-      return;
     }
     console.log('start loading page', curr);
     setTimeout(() => {
@@ -230,7 +250,7 @@ class Demo extends React.Component {
       <div >
         <div className="container">
           <ScrollList
-            className="scroll-list-demo"
+            className="scroll-list-demo scroll-list-cut-border"
             dataGetted={this.state.dataGetted}
             data={this.state.data}
             hasError={this.state.hasError}

--- a/demo/ScrollList/ScrollListDemo.jsx
+++ b/demo/ScrollList/ScrollListDemo.jsx
@@ -40,19 +40,23 @@ function getJsonp(page, size) {
 
 const propsMap = [
   {
-    title: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={20} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />标题文字(如姓名)</span>,
+    avatar: <Avatar name="tingle" size={20} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />,
+    title: <span className="newlist-demo-has-avatar">标题文字(如姓名)</span>,
     borderType: 'full-border',
   },
   {
-    description: <span className="newlist-demo-has-avatar"><Avatar name="tingle" size={40} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />标题文字(如姓名)</span>,
+    avatar: <Avatar name="tingle" size={40} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />,
+    description: <span className="newlist-demo-has-avatar">标题文字(如姓名)</span>,
     borderType: 'cut-border',
+    badge: 44,
   },
   {
     avatar: <Avatar name="tingle" size={40} src="https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png" />,
     title: '标题文字(如姓名)',
     description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
     borderType: 'no-border',
-    totalNumber: true,
+    badgePosition: 'indicator', // indicator/followTitle/titleRight
+    badge: true,
   },
   {
     avatar: 'https://img.alicdn.com/tfs/TB1TK47IHPpK1RjSZFFXXa5PpXa-238-238.png',
@@ -60,22 +64,23 @@ const propsMap = [
     description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
     borderType: 'cut-border',
     extra: <DirectionRight name="direction-right" className="newlist-demo-icon" />,
-    totalNumber: 10000,
+    badge: 10000,
+    badgePosition: 'indicator', // indicator/followTitle/titleRight
   },
   {
     img: 'https://gw.alicdn.com/tfs/TB15larRXXXXXbcXpXXXXXXXXXX-300-300.jpg',
     title: '标题文字(如姓名)',
-    className: 'badge-top-right',
-    badge: <Badge text="徽章文本" style={{ marginLeft: 10, background: '#ff6600' }} />,
+    badge: <Badge text="HOT" style={{ marginLeft: 10, background: '#ff6600' }} />,
+    badgePosition: 'titleRight', // indicator/followTitle/titleRight
     description: '放上人物相关简介和title，使人物信息更加饱满，文本内容文本内容文本内容文本内容文本内容文本内容文本内容文本内容',
     extra: <DirectionRight name="direction-right" className="newlist-demo-icon" />,
-    totalNumber: 4,
     borderType: 'no-border',
   },
   {
     img: 'https://gw.alicdn.com/tfs/TB15larRXXXXXbcXpXXXXXXXXXX-300-300.jpg',
     title: '标题文字(如姓名)',
-    badge: '徽章文本2',
+    badge: 'new',
+    badgePosition: 'followTitle', // indicator/followTitle/titleRight
     titleTag: '<span className="newlist-demo-has-title-tag">标题带标签</span>',
     description: '多行模式，文字超长则换行；文本内容文本内容文本内容文本内容文本内容文本内容',
   },

--- a/src/ScrollList/Item.jsx
+++ b/src/ScrollList/Item.jsx
@@ -8,21 +8,27 @@ class Item extends React.Component {
     prefixCls: PropTypes.string,
     className: PropTypes.string,
     img: PropTypes.string,
+    avatar: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     badge: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     desMaxLine: PropTypes.number,
+    totalNumber: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     extra: PropTypes.any,
+    borderType: PropTypes.string,
   };
   static defaultProps = {
     prefixCls: 't-scroll-list-item',
     desMaxLine: 2,
     className: undefined,
     img: undefined,
+    avatar: undefined,
     title: undefined,
     description: undefined,
     badge: undefined,
+    totalNumber: undefined,
     extra: undefined,
+    borderType: undefined,
   };
 
   renderImg() {
@@ -33,6 +39,14 @@ class Item extends React.Component {
     return img;
   }
 
+  renderAvatar() {
+    const { avatar, prefixCls } = this.props;
+    if (typeof avatar === 'string') {
+      return (<img alt="" className={`${prefixCls}-avatar`} src={avatar} />);
+    }
+    return avatar;
+  }
+
   renderTitle() {
     const { title, prefixCls } = this.props;
     return <div className={`${prefixCls}-title`}>{title}{this.renderBadge()}</div>;
@@ -41,7 +55,7 @@ class Item extends React.Component {
   renderBadge() {
     const { badge, prefixCls } = this.props;
     if (typeof badge === 'string') {
-      return (<Badge text={badge} style={{ marginLeft: 8, background: '#F9BD0F', }}/>);
+      return (<Badge text={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F9BD0F' }} />);
     }
     return badge;
   }
@@ -64,6 +78,26 @@ class Item extends React.Component {
     }
     return null;
   }
+
+  renderTotalNumber() {
+    const { totalNumber, prefixCls } = this.props;
+    if (!totalNumber || totalNumber <= 0) return null;
+    let num = '';
+    if (typeof totalNumber === 'number') {
+      num = totalNumber > 99 ? '99+' : totalNumber;
+    }
+    return (
+      <div
+        className={classnames(`${prefixCls}-number`, {
+        more: totalNumber > 99,
+        little: typeof totalNumber === 'boolean',
+      })}
+      >
+        {num}
+      </div>
+    );
+  }
+
   renderExtra() {
     const { extra, prefixCls } = this.props;
     if (extra) {
@@ -76,19 +110,22 @@ class Item extends React.Component {
     return null;
   }
   render() {
-    const { prefixCls, className } = this.props;
+    const { prefixCls, className, borderType } = this.props;
     return (
       <div
         className={classnames({
           [prefixCls]: true,
           [className]: !!className,
+          [borderType]: !!borderType,
         })}
       >
         {this.renderImg()}
+        {this.renderAvatar()}
         <div className={`${prefixCls}-content`}>
           {this.renderTitle()}
           {this.renderDes()}
         </div>
+        {this.renderTotalNumber()}
         {this.renderExtra()}
       </div>
     );

--- a/src/ScrollList/Item.jsx
+++ b/src/ScrollList/Item.jsx
@@ -11,9 +11,9 @@ class Item extends React.Component {
     avatar: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    badge: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    badge: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.number, PropTypes.bool]),
+    badgePosition: PropTypes.string,
     desMaxLine: PropTypes.number,
-    totalNumber: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     extra: PropTypes.any,
     borderType: PropTypes.string,
   };
@@ -26,9 +26,9 @@ class Item extends React.Component {
     title: undefined,
     description: undefined,
     badge: undefined,
-    totalNumber: undefined,
+    badgePosition: 'followTitle', // indicator/followTitle/titleRight
     extra: undefined,
-    borderType: undefined,
+    borderType: '',
   };
 
   renderImg() {
@@ -48,14 +48,24 @@ class Item extends React.Component {
   }
 
   renderTitle() {
-    const { title, prefixCls } = this.props;
-    return <div className={`${prefixCls}-title`}>{title}{this.renderBadge()}</div>;
+    const { title, prefixCls, badgePosition } = this.props;
+    if (!title) return null;
+    return (
+      <div className={classnames(`${prefixCls}-title`, {
+        [badgePosition]: true,
+      })}
+      >{title}{badgePosition === 'indicator' ? null : this.renderBadge()}
+      </div>);
   }
 
   renderBadge() {
     const { badge, prefixCls } = this.props;
     if (typeof badge === 'string') {
-      return (<Badge text={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F9BD0F' }} />);
+      return (<Badge text={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F04631' }} />);
+    } else if (typeof badge === 'number') {
+      return (<Badge count={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F04631' }} />);
+    } else if (typeof badge === 'boolean') {
+      return (<Badge dot style={{ marginLeft: 8, background: '#F04631' }} />);
     }
     return badge;
   }
@@ -79,25 +89,6 @@ class Item extends React.Component {
     return null;
   }
 
-  renderTotalNumber() {
-    const { totalNumber, prefixCls } = this.props;
-    if (!totalNumber || totalNumber <= 0) return null;
-    let num = '';
-    if (typeof totalNumber === 'number') {
-      num = totalNumber > 99 ? '99+' : totalNumber;
-    }
-    return (
-      <div
-        className={classnames(`${prefixCls}-number`, {
-        more: totalNumber > 99,
-        little: typeof totalNumber === 'boolean',
-      })}
-      >
-        {num}
-      </div>
-    );
-  }
-
   renderExtra() {
     const { extra, prefixCls } = this.props;
     if (extra) {
@@ -110,7 +101,9 @@ class Item extends React.Component {
     return null;
   }
   render() {
-    const { prefixCls, className, borderType } = this.props;
+    const {
+      prefixCls, className, borderType, badgePosition,
+    } = this.props;
     return (
       <div
         className={classnames({
@@ -125,7 +118,7 @@ class Item extends React.Component {
           {this.renderTitle()}
           {this.renderDes()}
         </div>
-        {this.renderTotalNumber()}
+        {badgePosition === 'indicator' ? this.renderBadge() : null}
         {this.renderExtra()}
       </div>
     );

--- a/src/ScrollList/Item.jsx
+++ b/src/ScrollList/Item.jsx
@@ -59,13 +59,13 @@ class Item extends React.Component {
   }
 
   renderBadge() {
-    const { badge, prefixCls } = this.props;
+    const { badge } = this.props;
     if (typeof badge === 'string') {
-      return (<Badge text={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F04631' }} />);
+      return (<Badge text={badge} />);
     } else if (typeof badge === 'number') {
-      return (<Badge count={badge} style={{ marginLeft: 8, marginTop: 1, background: '#F04631' }} />);
+      return (<Badge count={badge} />);
     } else if (typeof badge === 'boolean') {
-      return (<Badge dot style={{ marginLeft: 8, background: '#F04631' }} />);
+      return (<Badge dot />);
     }
     return badge;
   }

--- a/src/ScrollList/Item.jsx
+++ b/src/ScrollList/Item.jsx
@@ -59,13 +59,14 @@ class Item extends React.Component {
   }
 
   renderBadge() {
-    const { badge } = this.props;
+    const { badge, prefixCls } = this.props;
+    const className = `${prefixCls}-badge`;
     if (typeof badge === 'string') {
-      return (<Badge text={badge} />);
+      return (<Badge text={badge} className={className} />);
     } else if (typeof badge === 'number') {
-      return (<Badge count={badge} />);
+      return (<Badge count={badge} className={className} />);
     } else if (typeof badge === 'boolean') {
-      return (<Badge dot />);
+      return (<Badge dot className={className} />);
     }
     return badge;
   }

--- a/src/ScrollList/ScrollList.jsx
+++ b/src/ScrollList/ScrollList.jsx
@@ -90,7 +90,7 @@ class ScrollList extends React.Component {
     noDataTip: '暂无数据',
     noDataImage: 'https://img.alicdn.com/tps/TB1K6mHNpXXXXXiXpXXXXXXXXXX-1000-1000.svg',
     fetchDataOnOpen: true,
-    className: undefined,
+    className: 'scroll-list-full-border', // scroll-list-cut-border, scroll-list-no-border
     children: undefined,
     url: undefined,
     pageSize: undefined,

--- a/src/ScrollList/ScrollList.jsx
+++ b/src/ScrollList/ScrollList.jsx
@@ -31,6 +31,7 @@ class ScrollList extends React.Component {
   static propTypes = {
     prefixCls: PropTypes.string,
     className: PropTypes.string,
+    listBorderType: PropTypes.string,
     children: PropTypes.any,
     scrollLoad: PropTypes.bool,
     scrollRefresh: PropTypes.bool,
@@ -90,7 +91,8 @@ class ScrollList extends React.Component {
     noDataTip: '暂无数据',
     noDataImage: 'https://img.alicdn.com/tps/TB1K6mHNpXXXXXiXpXXXXXXXXXX-1000-1000.svg',
     fetchDataOnOpen: true,
-    className: 'scroll-list-no-border', // scroll-list-cut-border, scroll-list-full-border
+    className: undefined,
+    listBorderType: 'scroll-list-no-border', // scroll-list-no-border, scroll-list-cut-border, scroll-list-full-border
     children: undefined,
     url: undefined,
     pageSize: undefined,
@@ -384,6 +386,7 @@ class ScrollList extends React.Component {
         }}
         className={classnames(this.props.prefixCls, {
           [this.props.className]: !!this.props.className,
+          [this.props.listBorderType]: !!this.props.listBorderType,
         })}
         {...this.refreshOptions()}
         {...this.infiniteScrollOptions()}

--- a/src/ScrollList/ScrollList.jsx
+++ b/src/ScrollList/ScrollList.jsx
@@ -90,7 +90,7 @@ class ScrollList extends React.Component {
     noDataTip: '暂无数据',
     noDataImage: 'https://img.alicdn.com/tps/TB1K6mHNpXXXXXiXpXXXXXXXXXX-1000-1000.svg',
     fetchDataOnOpen: true,
-    className: 'scroll-list-full-border', // scroll-list-cut-border, scroll-list-no-border
+    className: 'scroll-list-no-border', // scroll-list-cut-border, scroll-list-full-border
     children: undefined,
     url: undefined,
     pageSize: undefined,

--- a/src/ScrollList/ScrollList.styl
+++ b/src/ScrollList/ScrollList.styl
@@ -7,6 +7,32 @@
  */
 $scrollListPrefixCls = t-scroll-list;
 
+.scroll-list-no-border {
+  .{$scrollListPrefixCls}-item {
+    border-bottom: 0px solid transparent;    
+  }
+}
+
+.scroll-list-full-border {
+  .{$scrollListPrefixCls}-item {
+    border-bottom: 1px solid $normal-alpha-7;    
+  }
+}
+
+.scroll-list-cut-border {
+  .{$scrollListPrefixCls}-item {
+    &:after {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: calc(100% - 16px);
+      bottom: 0;
+      right: 0;
+      background: $normal-alpha-7;
+    }
+  }
+}
+
 .{$scrollListPrefixCls} {
   overflow: hidden;
   margin: 0;
@@ -67,25 +93,55 @@ $scrollListPrefixCls = t-scroll-list;
 }
 
 .{$scrollListPrefixCls}-item {
-  padding: 16px 16px 12px;
+  padding: 16px;
   background: white;
   display: flex;
   line-height: 1.5;
   align-items: center;
   position: relative;
-  width: 100%;
+  // width: 100%;
   overflow: hidden;
-
-  &:after {
-    content: ' ';
-    position: absolute;
-    border-bottom: 1px solid $normal-alpha-7;
-    width: 100%;
-    bottom: 0;
-    left: 16px;
-  }
+  box-sizing: border-box;
+  // &:after {
+  //   content: ' ';
+  //   position: absolute;
+  //   border-bottom: 1px solid $normal-alpha-7;
+  //   width: 100%;
+  //   bottom: 0;
+  //   left: 16px;
+  // }
   &:active {
     background: $normal-alpha-7;
+  }
+  &.no-border {
+    border-bottom: 0px solid transparent;
+    &:after { 
+      display: none;  
+    }
+  }
+  &.full-border {
+    border-bottom: 1px solid $normal-alpha-7;
+    &:after { 
+      display: none;  
+    }
+  }
+  &.cut-border {
+    border-bottom: 0px solid transparent;
+    &:after {
+      position: absolute;
+      content: '';
+      height: 1px;
+      width: calc(100% - 16px);
+      bottom: 0;
+      right: 0;
+      background: $normal-alpha-7;
+    }
+  }
+  &:last-child  {
+    border-bottom: 0px solid transparent;
+    &:after { 
+      display: none;  
+    }
   }
 }
 
@@ -94,15 +150,24 @@ $scrollListPrefixCls = t-scroll-list;
   height: 40px;
   border-radius: $global-border-radius;
   align-self: baseline;
-  margin-right: 12px;
+  margin-right: 16px;
+}
+
+.{$scrollListPrefixCls}-item-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  align-self: baseline;
+  margin-right: 16px;
 }
 
 .{$scrollListPrefixCls}-item .t-avatar {
-    margin-right: 8px;
+    margin-right: 16px;
+    align-self: baseline;
 }
 
 .{$scrollListPrefixCls}-item .t-badge {
-  float: right;
+  // float: right;
   margin-bottom: 3px;
 }
 
@@ -113,17 +178,48 @@ $scrollListPrefixCls = t-scroll-list;
   min-width: 0;
 }
 
-.{$scrollListPrefixCls}-item-extra {
+.{$scrollListPrefixCls}-item-number {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  background: #F04631;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 12px;
   margin-left: 16px;
+  &.more {
+    width: 30px;
+    border-radius: 28px;
+  }
+  &.little {
+    width: 8px;
+    height: 8px;
+  }
+}
+
+.{$scrollListPrefixCls}-item-extra {
+  margin-left: 10px;
 }
 .{$scrollListPrefixCls}-item-extra-inner {
+  line-height: 
 }
 
 .{$scrollListPrefixCls}-item-title {
-  display: flex;
-  align-items: center;
+  // display: flex;
+  // align-items: center;
   font-size: 16px;
-  justify-content: space-between;
+  // justify-content: space-between;
+  color: rgba(0,0,0,.8);
+}
+
+.badge-top-right {
+  .{$scrollListPrefixCls}-item-title {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
 }
 
 .{$scrollListPrefixCls}-item-des-inner {

--- a/src/ScrollList/ScrollList.styl
+++ b/src/ScrollList/ScrollList.styl
@@ -99,17 +99,8 @@ $scrollListPrefixCls = t-scroll-list;
   line-height: 1.5;
   align-items: center;
   position: relative;
-  // width: 100%;
   overflow: hidden;
   box-sizing: border-box;
-  // &:after {
-  //   content: ' ';
-  //   position: absolute;
-  //   border-bottom: 1px solid $normal-alpha-7;
-  //   width: 100%;
-  //   bottom: 0;
-  //   left: 16px;
-  // }
   &:active {
     background: $normal-alpha-7;
   }
@@ -167,8 +158,11 @@ $scrollListPrefixCls = t-scroll-list;
 }
 
 .{$scrollListPrefixCls}-item .t-badge {
-  // float: right;
   margin-bottom: 3px;
+  .badge-inner {
+    background: $function-red;
+    margin: 1px 0 0 8px;
+  }
 }
 
 .{$scrollListPrefixCls}-item-content {
@@ -186,11 +180,8 @@ $scrollListPrefixCls = t-scroll-list;
 }
 
 .{$scrollListPrefixCls}-item-title {
-  // display: flex;
-  // align-items: center;
   font-size: 16px;
-  // justify-content: space-between;
-  color: rgba(0,0,0,.8);
+  color: $dark-alpha-2;
   &.titleRight {
     display: flex;
     align-items: baseline;

--- a/src/ScrollList/ScrollList.styl
+++ b/src/ScrollList/ScrollList.styl
@@ -178,27 +178,6 @@ $scrollListPrefixCls = t-scroll-list;
   min-width: 0;
 }
 
-.{$scrollListPrefixCls}-item-number {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  line-height: 20px;
-  text-align: center;
-  background: #F04631;
-  border-radius: 50%;
-  color: #fff;
-  font-size: 12px;
-  margin-left: 16px;
-  &.more {
-    width: 30px;
-    border-radius: 28px;
-  }
-  &.little {
-    width: 8px;
-    height: 8px;
-  }
-}
-
 .{$scrollListPrefixCls}-item-extra {
   margin-left: 10px;
 }
@@ -212,10 +191,7 @@ $scrollListPrefixCls = t-scroll-list;
   font-size: 16px;
   // justify-content: space-between;
   color: rgba(0,0,0,.8);
-}
-
-.badge-top-right {
-  .{$scrollListPrefixCls}-item-title {
+  &.titleRight {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
@@ -231,6 +207,7 @@ $scrollListPrefixCls = t-scroll-list;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   display: -webkit-box;
+  text-align: justify;
 }
 
 .hairline {

--- a/src/ScrollList/ScrollList.styl
+++ b/src/ScrollList/ScrollList.styl
@@ -157,7 +157,7 @@ $scrollListPrefixCls = t-scroll-list;
     align-self: baseline;
 }
 
-.{$scrollListPrefixCls}-item .t-badge {
+.{$scrollListPrefixCls}-item-badge {
   margin-bottom: 3px;
   .badge-inner {
     background: $function-red;


### PR DESCRIPTION
经下午和视觉验收之后，有了最新的方案和调整

1. 给列表item增加分割线，有List级别 和 Item级别 的`full-border` `cut-border` `no-border`， 默认 `full-border`，Item级别的设置会覆盖List级别的设置
2. item 增加 totalNumber， 可以是true（展示位小圆点），或者是数字（展示有数字的小圆点，大于99，显示99+）。
3. 徽章badge的位置有两种，一种位于右上角，一种紧随标题文字后面，默认改为跟随在大标题的文字后面，如有需要固定在右上角，可通过设置`classname`为 `badge-top-right`
4. 各模块间距调整统一为16px