### PR TITLE
fix: 兼容钉钉新的人员字段

### DIFF
--- a/src/EmployeeField/utils.js
+++ b/src/EmployeeField/utils.js
@@ -13,7 +13,7 @@ function transToValue(list) {
     let label;
     if (orgUserName) {
       // 兼容钉钉新字段
-      if (nick) {
+      if (nick && nick !== orgUserName) {
         label = `${orgUserName}(${nick})`;
       } else {
         label = orgUserName;

--- a/src/EmployeeField/utils.js
+++ b/src/EmployeeField/utils.js
@@ -1,12 +1,38 @@
 // 把 钉钉api 返回的值转换成 key/label 格式
 function transToValue(list) {
-  return (list || []).map(item => (
-    {
-      key: item.emplId,
-      label: item.nickNameCn || item.name,
-      avatar: item.avatar,
+  return (list || []).map((item) => {
+    const {
+      emplId,
+      nick,
+      nickNameCn,
+      name,
+      orgUserName,
+      avatar,
+    } = item;
+
+    let label;
+    if (orgUserName) {
+      // 兼容钉钉新字段
+      if (nick) {
+        label = `${orgUserName}(${nick})`;
+      } else {
+        label = orgUserName;
+      }
+    } else if (name) {
+      // 原有逻辑，调整为 姓名(花名) 的方式
+      if (nickNameCn && nickNameCn !== name) {
+        label = `${name}(${nickNameCn})`;
+      } else {
+        label = name;
+      }
     }
-  ));
+
+    return {
+      key: emplId,
+      label,
+      avatar,
+    };
+  });
 }
 
 export default { transToValue };


### PR DESCRIPTION
* 当有 `orgUserName` 时，优先配合 `nick` 字段使用；
* 原有模式时，尝试给出 `姓名(花名)` 的结果；