### PR TITLE
fix: Datetime render error if minDate is set and value is undefined

### DIFF
--- a/demo/DatetimeField/DatetimeFieldDemo.jsx
+++ b/demo/DatetimeField/DatetimeFieldDemo.jsx
@@ -117,7 +117,8 @@ class Demo extends React.Component {
               value={t.state.value4}
               columns={DatetimeField.YMDWHM}
               disabledTime={disabledTime}
-              layout={'v'}
+              // minDate={new Date(2019, 8, 10).getTime()}
+              layout="v"
               // disabledDate={() => [
               //     {
               //       start: new Date(2017, 5, 1),

--- a/src/Datetime/Datetime.jsx
+++ b/src/Datetime/Datetime.jsx
@@ -99,7 +99,8 @@ class Datetime extends React.Component {
 
   static getValidValue(props) {
     const { minDate, maxDate, value } = props;
-    const validValue = new Date(value).getTime();
+    // value 为 undefined 时，new Date 返回为 invalid Date，与不传的效果不同
+    const validValue = value ? new Date(value).getTime() : new Date().getTime();
     const minStamp = new Date(minDate).getTime();
     const maxStamp = new Date(maxDate).getTime();
     if (validValue < minStamp) {


### PR DESCRIPTION
 new Date value 为 undefined 时，new Date 返回为 invalid Date，与不传的效果不同。之前的写法没有考虑 value 为空的情况，导致该情况下如果有 minDate ，会有渲染报错。