### PR TITLE
Update ScrollList.jsx

### DIFF
--- a/src/ScrollList/ScrollList.jsx
+++ b/src/ScrollList/ScrollList.jsx
@@ -228,7 +228,9 @@ class ScrollList extends React.Component {
         nextState.showRefreshing = true;
         this.setState(nextState, () => {
           if (refresh) {
-            this.scrollViewRef.tryEmitScrollEvent();
+            if(this.scrollViewRef){
+              this.scrollViewRef.tryEmitScrollEvent();
+            }
           }
         });
       })


### PR DESCRIPTION
当再次调用fetchData方法时报错
TypeError: Cannot read properties of null (reading 'tryEmitScrollEvent')
增加对this.scrollViewRef的判断